### PR TITLE
feat: Add Docker Compose setup for MongoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### MongoDB ###
+data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '4'
+services:
+  mongodb:
+    image: mongo:7.0.5
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    environment:
+      MONGODB_INITDB_ROOT_USERNAME: root
+      MONGODB_INITDB_ROOT_PASSWORD: password
+      MONGODB_INITDB_DATABASE: product-service
+    volumes:
+      - ./data:/data/db


### PR DESCRIPTION
This commit adds a docker-compose.yml file to configure a MongoDB container. The setup includes:
- MongoDB service on port 27017
- Initializing a root user and password
- Creating a 'product-service' database
- Mounting a local volume for data persistence